### PR TITLE
Move to puppet/download_file as suggested by source

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":         "opentable-iis_rewrite",
-  "version":      "1.0.0",
+  "version":      "1.0.1",
   "author":       "opentable",
   "license":      "MIT",
   "source":       "https://github.com/opentable/iis_rewrite",
@@ -20,8 +20,8 @@
       "version_requirement": ">= 3.0.0 <5.0.0"
     },
     {
-      "name": "opentable/download_file",
-      "version_requirement": ">= 0.0.2 <1.0.0"
+      "name": "puppet/download_file",
+      "version_requirement": ">= 1.0.0 <2.0.0"
     },
     {
       "name": "puppetlabs/powershell",


### PR DESCRIPTION
We were running into https://github.com/puppet-community/puppet-download_file/issues/10, since fixed in the puppet/download_file module, but iis_rewrite was still referencing the original (pre-fix) opentable/download_file as a dependency.

This PR updates its dependency to point at the newer version of download_file.

I wasn't sure what to rev the version number to - I guess under semver it should probably be 2.0.0 since it includes a major version rev to a dependency, but I don't see any obvious breaking changes in the dependency, so it may be a little excessive?